### PR TITLE
fix SBCL WARNINGs that disasslowed ASDF:LOAD-SYSTEM

### DIFF
--- a/src/ar.lisp
+++ b/src/ar.lisp
@@ -22,10 +22,18 @@
   generator
   content)
 
+(deftype marray ()
+  `(or cl:array hash-table mgenarray))
+
+(defun marrayp (x)
+  (typep x 'marray))
+
 (defun marray-type (x)
-  (cond ((arrayp x) 'array)
-        ((hash-table-p x) 'hash-table)
-        ((eq (type-of x) 'mgenarray) (mgenarray-type x))))
+  ;; XXX: should this be etypecase? -rss
+  (typecase x
+    (cl:array   'array)
+    (hash-table 'hash-table)
+    (mgenarray  (mgenarray-type x))))
 
 (defmfun $make_array (type &rest diml)
   (let ((ltype (assoc type '(($float . flonum)
@@ -91,7 +99,7 @@
         (msize-atom (format nil "{Lisp Array: ~A}" x) l r))))
 
 (defun marray-check (a)
-  (if (arrayp a)
+  (if (marrayp a)
       (case (marray-type a)
 	(($fixnum $float) a)
 	(($any) (mgenarray-content a))

--- a/src/commac.lisp
+++ b/src/commac.lisp
@@ -281,16 +281,17 @@ values")
 ;;sample usage
 ;;(defun foo a (show a )(show (listify a)) (show (arg 3)))
 
-(defmacro defun-maclisp (function &body  rest &aux .n.)
-  (cond ((and (car rest) (symbolp (car rest)))
-	 ;;old maclisp narg syntax
-	 (setq .n. (car rest))
-	 (setf (car rest)
-	       `(&rest narg-rest-argument &aux (, .n. (length narg-rest-argument))))))
+(defmacro defun-maclisp (function &body body &aux .n.)
+  (when (typep body '(cons symbol))
+    ;;old maclisp narg syntax
+    (setq .n. (car body))
+    (setf body
+          (cons `(&rest narg-rest-argument &aux (, .n. (length narg-rest-argument)))
+                (cdr body))))
   `(progn
     ;; I (rtoy) think we can consider all defmfun's as translated functions.
     (defprop ,function t translated)
-    (defun ,function . ,rest)))
+    (defun ,function . ,body)))
 
 (defun exploden (symb)
   (let* (#+(and gcl (not gmp)) (big-chunk-size 120)


### PR DESCRIPTION
This fixes warnings that get reported as errors by (ASDF:LOAD-SYSTEM :MAXIMA). The warnings are actual program errors (e.g., accessing the 'type' slot of a CL:ARRAY).